### PR TITLE
fix(linting-rules): add missing type in tag

### DIFF
--- a/libs/ddd/src/schematics/utils/update-linting-rules.ts
+++ b/libs/ddd/src/schematics/utils/update-linting-rules.ts
@@ -85,7 +85,7 @@ export function initLintingRules(): Rule {
     });
 
     depConst.push({
-      'sourceTag': 'domain-logic',
+      'sourceTag': 'type:domain-logic',
       'onlyDependOnLibsWithTags': ['type:util']
     });
 


### PR DESCRIPTION
I suppose the `type:` is missing here in the tag definition