### PR TITLE
feat(domain,feature): add property to specify build type

### DIFF
--- a/libs/ddd/src/schematics/domain/index.ts
+++ b/libs/ddd/src/schematics/domain/index.ts
@@ -29,6 +29,8 @@ export default function(options: DomainOptions): Rule {
       tags: `domain:${options.name},type:domain-logic`,
       style: 'scss',
       prefix: options.name,
+      publishable: options.type === 'publishable',
+      buildable: options.type === 'buildable',
     }),
     addDomainToLintingRules(options.name),
     mergeWith(templateSource),

--- a/libs/ddd/src/schematics/domain/schema.json
+++ b/libs/ddd/src/schematics/domain/schema.json
@@ -15,6 +15,16 @@
       "type": "boolean",
       "description": "Add an app for the domain?",
       "default": false
+    },
+    "type": {
+      "type": "string",
+      "enum": [
+        "internal",
+        "buildable",
+        "publishable"
+      ],
+      "description": "A type to determine if and how to build the library.",
+      "default": "publishable"
     }
   },
   "required": ["name"]

--- a/libs/ddd/src/schematics/domain/schema.ts
+++ b/libs/ddd/src/schematics/domain/schema.ts
@@ -14,5 +14,9 @@ export interface DomainOptions {
    * Add an app for the domain?
    */
   addApp?: boolean;
+  /**
+   * A type to determine if and how to build the library.
+   */
+  type?: "internal" | "buildable" | "publishable";
   [k: string]: any;
 }

--- a/libs/ddd/src/schematics/feature/index.ts
+++ b/libs/ddd/src/schematics/feature/index.ts
@@ -181,6 +181,8 @@ export default function(options: FeatureOptions): Rule {
         tags: `domain:${options.domain},type:feature`,
         style: 'scss',
         prefix: options.domain,
+        publishable: options.type === 'publishable',
+        buildable: options.type === 'buildable',
       }),
       addImport(featureModulePath, domainImportPath, domainModuleClassName),
       (!options.lazy && host.exists(appModulePath)) ? 

--- a/libs/ddd/src/schematics/feature/schema.json
+++ b/libs/ddd/src/schematics/feature/schema.json
@@ -27,6 +27,16 @@
     "entity": {
       "type": "string",
       "description": "Optional entity to create for this feature"
+    },
+    "type": {
+      "type": "string",
+      "enum": [
+        "internal",
+        "buildable",
+        "publishable"
+      ],
+      "description": "A type to determine if and how to build the library.",
+      "default": "publishable"
     }
   },
   "required": ["name", "domain"]

--- a/libs/ddd/src/schematics/feature/schema.ts
+++ b/libs/ddd/src/schematics/feature/schema.ts
@@ -26,5 +26,9 @@ export interface FeatureOptions {
    * Optional entity to create for this feature
    */
   entity?: string;
+  /**
+   * A type to determine if and how to build the library.
+   */
+  type?: "internal" | "buildable" | "publishable";
   [k: string]: any;
 }


### PR DESCRIPTION
I was having issues with a few things, when working with the repo:
* When pulling the latest version from npm, I received code which had the publishable flag always being set to true when creating angular libs via the nrwl angular library schematic. I could, however, not find that in the current master branch of the repo. Is the repo out of sync with the npm deployment?
* Testing the schematics locally (via e2e testing or directly via the CLI) did not work out of the box for me. Is the setup a bit broken or did I miss something? I'd be happy to help out, if there are some problems with the setup.

Currently, the buildable flag is not yet supported in the latest nx release (see [this issue](https://github.com/nrwl/nx/issues/2794)), so setting the type to "buildable" would create a lib without build target (which would be the same like using type "internal"). 

Closes #9 