### PR TITLE
fix: use expected path when generating a domain or feature

### DIFF
--- a/libs/ddd/src/schematics/domain/index.ts
+++ b/libs/ddd/src/schematics/domain/index.ts
@@ -33,7 +33,7 @@ export default function (options: DomainOptions): Rule {
 
   const libName = strings.dasherize(options.name);
   const libNameAndDirectory = options.directory
-    ? `${libName}/${options.directory}`
+    ? `${options.directory}/${libName}`
     : libName;
   const libNameAndDirectoryDasherized = strings
     .dasherize(libNameAndDirectory)

--- a/libs/ddd/src/schematics/feature/index.ts
+++ b/libs/ddd/src/schematics/feature/index.ts
@@ -48,7 +48,7 @@ export default function (options: FeatureOptions): Rule {
       .split('/')
       .join('-');
     const domainNameAndDirectory = domainDirectory
-    ? `${domainName}/${domainDirectory}`
+    ? `${domainDirectory}/${domainName}`
     : `${domainName}`;
     const domainNameAndDirectoryDasherized = `${domainNameAndDirectory}`
       .split('/')


### PR DESCRIPTION
The `--directory` parameter introduced in #35 is used to determine the path when generating a domain library. Similarly, the `--domainDirectory` flag is used when generating a feature library. This PR corrects the usage of these flags so that the given `--directory` or `--domainDirectory` appears before the domain's name in the path instead of appearing after.

For example, this command:

`ng g @angular-architects/ddd:domain user --directory=management`

Will now generate the path `libs/management/user/domain` instead of `libs/user/management/domain`.

Fixes #79
Fixes #12