### PR TITLE
feature: update ngrx version to 13.0.1

### DIFF
--- a/libs/ddd/src/schematics/utils/ngrx-version.ts
+++ b/libs/ddd/src/schematics/utils/ngrx-version.ts
@@ -1,1 +1,1 @@
-export const NGRX_VERSION = '10.1.2';
+export const NGRX_VERSION = '13.0.1';


### PR DESCRIPTION
When running schematics and adding the ngrx flag, the following error occurs

```
npx ng g @angular-architects/ddd:feature damage-assessment --domain olb --entity damage --ngrx --type publishable --app example --importPath @ewp/olb/damage-assessment                    
⠸ Installing packages (npm)...npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: enterprise-web-platform@0.0.0
npm ERR! Found: @angular/core@13.0.2
npm ERR! node_modules/@angular/core
npm ERR!   @angular/core@"^13.0.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer @angular/core@"^10.0.0" from @ngrx/effects@10.1.2
npm ERR! node_modules/@ngrx/effects
npm ERR!   @ngrx/effects@"10.1.2" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! See /home/mehrad/.npm/eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/mehrad/.npm/_logs/2021-11-30T13_52_12_144Z-debug.log
✖ Package install failed, see above.
UnsuccessfulWorkflowExecution [Error]: Workflow did not execute successfully.
    at ChildProcess.<anonymous> (/home/mehrad/dev/work/enterprise-web-platform/node_modules/@angular-devkit/schematics/tasks/package-manager/executor.js:134:31)
    at ChildProcess.emit (events.js:400:28)
    at maybeClose (internal/child_process.js:1055:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:288:5)
The generator workflow failed. See above.
```