### PR TITLE
fix: add eslint.config.mjs support

### DIFF
--- a/libs/ddd/src/generators/utils/update-dep-const.ts
+++ b/libs/ddd/src/generators/utils/update-dep-const.ts
@@ -25,8 +25,11 @@ export function updateDepConst(
       filePath = 'eslint.config.cjs';
       console.info('Found .eslintrc');
       isJson = false;
-    }  
-    else {
+    } else if (host.exists('eslint.config.mjs')) {
+      filePath = 'eslint.config.mjs';
+      console.info('Found .eslintrc');
+      isJson = false;
+    } else {
       console.info(
         'Cannot add linting rules: linting config file does not exist'
       );


### PR DESCRIPTION
Currently running `nx g @angular-architects/ddd:init` in a Nx 20.7.2 application, the following error is thrown:

```
NX Generating @angular-architects/ddd:init

Cannot add linting rules: linting config file does not exist
```

This is due to eslint.config files being generated as `.mjs` instead of supported `.cjs`. This PR adds support for such files.